### PR TITLE
Implement basic system calls in Rust

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -8,6 +8,9 @@ cp ./target/x86_64-unknown-uefi/debug/horse-bootloader.efi ../dev-tools
 cd ../kernel
 cargo build
 cp ./horse-kernel ../dev-tools
+cd ../gallop
+cargo build --release
+cp ./target/x86_64-horse-user/release/gallop ../dev-tools/
 cd ../
 ''']
 
@@ -20,6 +23,7 @@ DISK_IMG=Horse.iso
 MOUNT_POINT=mnt
 EFI_FILE=./dev-tools/horse-bootloader.efi
 ANOTHER_FILE=kernel/horse-kernel
+GALLOP_FILE=./dev-tools/gallop
 
 if [ ! -f $EFI_FILE ]
 then
@@ -39,6 +43,10 @@ sudo cp $EFI_FILE $MOUNT_POINT/EFI/BOOT/BOOTX64.EFI
 if [ "$ANOTHER_FILE" != "" ]
 then
     sudo cp $ANOTHER_FILE $MOUNT_POINT/
+fi
+if [ -f "$GALLOP_FILE" ]
+then
+    sudo cp $GALLOP_FILE $MOUNT_POINT/
 fi
 sleep 0.5
 sudo umount $MOUNT_POINT

--- a/gallop/.cargo/config.toml
+++ b/gallop/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "x86_64-horse-user.json"
+
+[unstable]
+build-std = ["core"]
+build-std-features = ["compiler-builtins-mem"]
+
+[target.x86_64-horse-user]
+runner = "echo 'Built ELF:'"

--- a/gallop/Cargo.toml
+++ b/gallop/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "gallop"
+version = "0.1.0"
+edition = "2021"
+description = "Example user-space program for Horse OS"
+
+[dependencies]
+horse_syscall = { path = "../horse_syscall" }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+opt-level = "z"      # Optimize for size
+lto = true           # Link-time optimization

--- a/gallop/link.ld
+++ b/gallop/link.ld
@@ -1,0 +1,49 @@
+/* Linker script for Horse OS user-space programs */
+
+/* Entry point */
+ENTRY(_start)
+
+/* User program base address */
+/* This should match what the kernel's ELF loader expects */
+USER_BASE = 0x400000;
+
+SECTIONS
+{
+    /* Start at the user base address */
+    . = USER_BASE;
+
+    /* Code section */
+    .text : ALIGN(4K)
+    {
+        *(.text .text.*)
+    }
+
+    /* Read-only data */
+    .rodata : ALIGN(4K)
+    {
+        *(.rodata .rodata.*)
+    }
+
+    /* Initialized data */
+    .data : ALIGN(4K)
+    {
+        *(.data .data.*)
+    }
+
+    /* Uninitialized data (BSS) */
+    .bss : ALIGN(4K)
+    {
+        __bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        __bss_end = .;
+    }
+
+    /* Discard unnecessary sections */
+    /DISCARD/ :
+    {
+        *(.eh_frame)
+        *(.note.*)
+        *(.comment)
+    }
+}

--- a/gallop/rust-toolchain.toml
+++ b/gallop/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]

--- a/gallop/src/main.rs
+++ b/gallop/src/main.rs
@@ -1,0 +1,51 @@
+//! Hello World program for Horse OS
+//!
+//! This is a minimal user-space program that demonstrates
+//! using system calls via the horse_syscall library.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use horse_syscall::prelude::*;
+
+/// Entry point for the application
+///
+/// This function is called by the OS after loading the ELF.
+/// The name `_start` is the conventional entry point for ELF executables.
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    // Print Hello World using the write system call
+    let message = b"Hello, World from Horse OS!\n";
+    let _ = write(STDOUT, message);
+
+    // Since we don't have an exit syscall yet, loop forever
+    // In a real program, you would call exit(0) here
+    loop {
+        // Hint to the CPU that we're in a spin loop
+        core::hint::spin_loop();
+    }
+}
+
+/// Panic handler
+///
+/// Required for no_std programs. Called when the program panics.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    // Try to print panic message to stderr
+    let _ = write(STDERR, b"PANIC: ");
+
+    if let Some(location) = info.location() {
+        // We can't easily format strings in no_std without alloc,
+        // so just print a generic message
+        let _ = write(STDERR, b"at ");
+        let _ = write(STDERR, location.file().as_bytes());
+        let _ = write(STDERR, b"\n");
+    } else {
+        let _ = write(STDERR, b"unknown location\n");
+    }
+
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/gallop/x86_64-horse-user.json
+++ b/gallop/x86_64-horse-user.json
@@ -1,0 +1,21 @@
+{
+    "arch": "x86_64",
+    "cpu": "x86-64",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+    "executables": true,
+    "linker": "ld.lld",
+    "linker-flavor": "ld",
+    "llvm-target": "x86_64-unknown-none-elf",
+    "max-atomic-width": 64,
+    "panic-strategy": "abort",
+    "disable-redzone": true,
+    "post-link-args": {
+        "ld": [
+            "-Tlink.ld",
+            "-static",
+            "-nostdlib"
+        ]
+    },
+    "relocation-model": "static",
+    "target-pointer-width": 64
+}

--- a/horse_syscall/Cargo.toml
+++ b/horse_syscall/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "horse_syscall"
+version = "0.1.0"
+edition = "2021"
+authors = ["Horse OS Contributors"]
+description = "System call wrapper library for Horse OS user-space applications"
+license = "MIT"
+
+[lib]
+name = "horse_syscall"
+crate-type = ["rlib"]
+
+[dependencies]
+
+[features]
+default = []

--- a/horse_syscall/README.md
+++ b/horse_syscall/README.md
@@ -1,0 +1,105 @@
+# horse_syscall
+
+System call wrapper library for Horse OS user-space applications.
+
+## Overview
+
+This crate provides a safe and ergonomic interface to Horse OS system calls, allowing `#![no_std]` applications to interact with the kernel.
+
+## Features
+
+- **Raw syscall functions**: `syscall0` through `syscall6` for direct system call invocation
+- **File operations**: `open`, `read`, `write`, `close`
+- **RAII File wrapper**: Automatic resource cleanup
+- **I/O utilities**: `print!`, `println!`, `eprint!`, `eprintln!` macros
+- **Error handling**: Rust-style `Result` types
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+horse_syscall = { path = "../horse_syscall" }
+```
+
+## Quick Start
+
+```rust
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use horse_syscall::prelude::*;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    // Write to stdout
+    let _ = write(STDOUT, b"Hello from Horse OS!\n");
+
+    // Open and read a file
+    if let Ok(fd) = open("/test.txt", OpenFlags::RDONLY) {
+        let mut buf = [0u8; 256];
+        if let Ok(n) = read(fd, &mut buf) {
+            let _ = write(STDOUT, &buf[..n]);
+        }
+        let _ = close(fd);
+    }
+
+    loop {}
+}
+
+#[panic_handler]
+fn panic(_: &PanicInfo) -> ! {
+    loop {}
+}
+```
+
+## API Reference
+
+### System Call Numbers
+
+| Number | Name  | Description           |
+|--------|-------|-----------------------|
+| 0      | read  | Read from file        |
+| 1      | write | Write to file         |
+| 2      | open  | Open file             |
+| 3      | close | Close file descriptor |
+
+### File Descriptors
+
+| FD | Name   | Description     |
+|----|--------|-----------------|
+| 0  | STDIN  | Standard input  |
+| 1  | STDOUT | Standard output |
+| 2  | STDERR | Standard error  |
+
+### Open Flags
+
+| Flag        | Value  | Description                  |
+|-------------|--------|------------------------------|
+| RDONLY      | 0x0000 | Open for reading only        |
+| WRONLY      | 0x0001 | Open for writing only        |
+| RDWR        | 0x0002 | Open for reading and writing |
+| CREAT       | 0x0100 | Create if doesn't exist      |
+| TRUNC       | 0x0200 | Truncate to zero length      |
+| APPEND      | 0x0400 | Append to file               |
+
+## Calling Convention
+
+Horse OS uses the following x86-64 calling convention for system calls:
+
+- `RAX`: System call number
+- `RDI`: First argument
+- `RSI`: Second argument
+- `RDX`: Third argument
+- `R10`: Fourth argument
+- `R8`:  Fifth argument
+- `R9`:  Sixth argument
+- Return value in `RAX`
+
+System calls are invoked using `int 0x80`.
+
+## License
+
+MIT License

--- a/horse_syscall/examples/file_io.rs
+++ b/horse_syscall/examples/file_io.rs
@@ -1,0 +1,70 @@
+//! File I/O example for Horse OS
+//!
+//! This example demonstrates reading from a file using horse_syscall.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use horse_syscall::prelude::*;
+use horse_syscall::fs::File;
+
+/// Entry point for the application
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    let _ = write(STDOUT, b"File I/O Example\n");
+    let _ = write(STDOUT, b"================\n\n");
+
+    // Method 1: Using low-level functions
+    let _ = write(STDOUT, b"Opening /test.txt...\n");
+
+    match open("/test.txt", OpenFlags::RDONLY) {
+        Ok(fd) => {
+            let _ = write(STDOUT, b"File opened successfully!\n");
+
+            let mut buf = [0u8; 256];
+            match read(fd, &mut buf) {
+                Ok(n) => {
+                    let _ = write(STDOUT, b"Read ");
+                    // Note: We can't easily print the number without format support
+                    let _ = write(STDOUT, b" bytes:\n");
+                    let _ = write(STDOUT, &buf[..n]);
+                    let _ = write(STDOUT, b"\n");
+                }
+                Err(_) => {
+                    let _ = write(STDERR, b"Failed to read file\n");
+                }
+            }
+
+            let _ = close(fd);
+            let _ = write(STDOUT, b"File closed.\n");
+        }
+        Err(_) => {
+            let _ = write(STDERR, b"Failed to open file\n");
+        }
+    }
+
+    // Method 2: Using the File wrapper (RAII)
+    let _ = write(STDOUT, b"\nUsing File wrapper:\n");
+
+    if let Ok(file) = File::open("/test.txt", OpenFlags::RDONLY) {
+        let mut buf = [0u8; 256];
+        if let Ok(n) = file.read(&mut buf) {
+            let _ = write(STDOUT, b"Content: ");
+            let _ = write(STDOUT, &buf[..n]);
+            let _ = write(STDOUT, b"\n");
+        }
+        // File automatically closed when dropped
+    }
+
+    let _ = write(STDOUT, b"\nDone!\n");
+
+    loop {}
+}
+
+/// Panic handler
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    let _ = write(STDERR, b"PANIC!\n");
+    loop {}
+}

--- a/horse_syscall/examples/hello.rs
+++ b/horse_syscall/examples/hello.rs
@@ -1,0 +1,30 @@
+//! Hello World example for Horse OS
+//!
+//! This is a minimal example showing how to use horse_syscall
+//! to write a "Hello, World!" program.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use horse_syscall::prelude::*;
+
+/// Entry point for the application
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    // Simple way: use the write function directly
+    let _ = write(STDOUT, b"Hello from Horse OS!\n");
+
+    // Using the print! macro (requires core::fmt::Write)
+    // horse_syscall::println!("Hello, {}!", "World");
+
+    // Infinite loop (we don't have exit syscall yet)
+    loop {}
+}
+
+/// Panic handler - required for no_std
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    let _ = write(STDERR, b"PANIC!\n");
+    loop {}
+}

--- a/horse_syscall/src/error.rs
+++ b/horse_syscall/src/error.rs
@@ -1,0 +1,98 @@
+//! Error types for system call results
+
+use core::fmt;
+
+/// System call error codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(isize)]
+pub enum Error {
+    /// Operation not permitted
+    Perm = -1,
+    /// No such file or directory
+    NoEnt = -2,
+    /// I/O error
+    Io = -5,
+    /// Bad file descriptor
+    BadFd = -9,
+    /// Try again
+    Again = -11,
+    /// Out of memory
+    NoMem = -12,
+    /// Permission denied
+    Access = -13,
+    /// File exists
+    Exist = -17,
+    /// Not a directory
+    NotDir = -20,
+    /// Is a directory
+    IsDir = -21,
+    /// Invalid argument
+    Inval = -22,
+    /// Too many open files
+    MFile = -24,
+    /// Function not implemented
+    NoSys = -38,
+    /// Unknown error
+    Unknown = -255,
+}
+
+impl Error {
+    /// Create an Error from a raw system call return value
+    pub fn from_syscall_ret(ret: isize) -> Self {
+        match ret {
+            -1 => Error::Perm,
+            -2 => Error::NoEnt,
+            -5 => Error::Io,
+            -9 => Error::BadFd,
+            -11 => Error::Again,
+            -12 => Error::NoMem,
+            -13 => Error::Access,
+            -17 => Error::Exist,
+            -20 => Error::NotDir,
+            -21 => Error::IsDir,
+            -22 => Error::Inval,
+            -24 => Error::MFile,
+            -38 => Error::NoSys,
+            _ => Error::Unknown,
+        }
+    }
+
+    /// Get the error code as an isize
+    pub fn code(self) -> isize {
+        self as isize
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Perm => write!(f, "Operation not permitted"),
+            Error::NoEnt => write!(f, "No such file or directory"),
+            Error::Io => write!(f, "I/O error"),
+            Error::BadFd => write!(f, "Bad file descriptor"),
+            Error::Again => write!(f, "Try again"),
+            Error::NoMem => write!(f, "Out of memory"),
+            Error::Access => write!(f, "Permission denied"),
+            Error::Exist => write!(f, "File exists"),
+            Error::NotDir => write!(f, "Not a directory"),
+            Error::IsDir => write!(f, "Is a directory"),
+            Error::Inval => write!(f, "Invalid argument"),
+            Error::MFile => write!(f, "Too many open files"),
+            Error::NoSys => write!(f, "Function not implemented"),
+            Error::Unknown => write!(f, "Unknown error"),
+        }
+    }
+}
+
+/// Result type for system call operations
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Convert a raw syscall return value to a Result
+#[inline]
+pub fn check_syscall(ret: isize) -> Result<usize> {
+    if ret < 0 {
+        Err(Error::from_syscall_ret(ret))
+    } else {
+        Ok(ret as usize)
+    }
+}

--- a/horse_syscall/src/fs.rs
+++ b/horse_syscall/src/fs.rs
@@ -1,0 +1,248 @@
+//! File system operations
+//!
+//! This module provides safe wrappers around file-related system calls.
+
+use crate::error::{check_syscall, Result};
+use crate::raw::{syscall1, syscall2, syscall3, Fd, SyscallNum};
+
+/// File open flags
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenFlags(u32);
+
+impl OpenFlags {
+    /// Open for reading only
+    pub const RDONLY: Self = Self(0x0000);
+    /// Open for writing only
+    pub const WRONLY: Self = Self(0x0001);
+    /// Open for reading and writing
+    pub const RDWR: Self = Self(0x0002);
+    /// Create file if it doesn't exist
+    pub const CREAT: Self = Self(0x0100);
+    /// Truncate file to zero length
+    pub const TRUNC: Self = Self(0x0200);
+    /// Append to file
+    pub const APPEND: Self = Self(0x0400);
+
+    /// Create a new OpenFlags with the given raw value
+    pub const fn from_bits(bits: u32) -> Self {
+        Self(bits)
+    }
+
+    /// Get the raw bits of the flags
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Combine two flags
+    pub const fn or(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+impl core::ops::BitOr for OpenFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl core::ops::BitOrAssign for OpenFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// Open a file
+///
+/// # Arguments
+///
+/// * `path` - Path to the file (null-terminated or slice)
+/// * `flags` - Open flags (see [`OpenFlags`])
+///
+/// # Returns
+///
+/// * `Ok(fd)` - File descriptor on success
+/// * `Err(e)` - Error on failure
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::fs::{open, OpenFlags};
+///
+/// let fd = open("/test.txt", OpenFlags::RDONLY)?;
+/// ```
+pub fn open(path: &str, flags: OpenFlags) -> Result<Fd> {
+    // We need a null-terminated string for the syscall
+    // Since we're in no_std, we'll use a stack buffer
+    let path_bytes = path.as_bytes();
+    if path_bytes.len() >= 4096 {
+        return Err(crate::error::Error::Inval);
+    }
+
+    // Create null-terminated path on stack
+    let mut buf = [0u8; 4096];
+    buf[..path_bytes.len()].copy_from_slice(path_bytes);
+    // buf is already zero-initialized, so it's null-terminated
+
+    let ret = unsafe {
+        syscall2(
+            SyscallNum::Open as usize,
+            buf.as_ptr() as usize,
+            flags.bits() as usize,
+        )
+    };
+
+    check_syscall(ret).map(|fd| fd as Fd)
+}
+
+/// Open a file with a null-terminated path (more efficient)
+///
+/// # Safety
+///
+/// The path must be a valid null-terminated C string.
+pub unsafe fn open_cstr(path: *const u8, flags: OpenFlags) -> Result<Fd> {
+    let ret = syscall2(
+        SyscallNum::Open as usize,
+        path as usize,
+        flags.bits() as usize,
+    );
+    check_syscall(ret).map(|fd| fd as Fd)
+}
+
+/// Read from a file descriptor
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor
+/// * `buf` - Buffer to read into
+///
+/// # Returns
+///
+/// * `Ok(n)` - Number of bytes read
+/// * `Err(e)` - Error on failure
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::fs::read;
+///
+/// let mut buf = [0u8; 256];
+/// let n = read(fd, &mut buf)?;
+/// ```
+pub fn read(fd: Fd, buf: &mut [u8]) -> Result<usize> {
+    let ret = unsafe {
+        syscall3(
+            SyscallNum::Read as usize,
+            fd as usize,
+            buf.as_mut_ptr() as usize,
+            buf.len(),
+        )
+    };
+    check_syscall(ret)
+}
+
+/// Write to a file descriptor
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor
+/// * `buf` - Buffer to write from
+///
+/// # Returns
+///
+/// * `Ok(n)` - Number of bytes written
+/// * `Err(e)` - Error on failure
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::fs::write;
+///
+/// let n = write(fd, b"Hello, World!\n")?;
+/// ```
+pub fn write(fd: Fd, buf: &[u8]) -> Result<usize> {
+    let ret = unsafe {
+        syscall3(
+            SyscallNum::Write as usize,
+            fd as usize,
+            buf.as_ptr() as usize,
+            buf.len(),
+        )
+    };
+    check_syscall(ret)
+}
+
+/// Close a file descriptor
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor to close
+///
+/// # Returns
+///
+/// * `Ok(())` - Success
+/// * `Err(e)` - Error on failure
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::fs::close;
+///
+/// close(fd)?;
+/// ```
+pub fn close(fd: Fd) -> Result<()> {
+    let ret = unsafe { syscall1(SyscallNum::Close as usize, fd as usize) };
+    check_syscall(ret).map(|_| ())
+}
+
+/// A file handle that automatically closes when dropped
+#[derive(Debug)]
+pub struct File {
+    fd: Fd,
+}
+
+impl File {
+    /// Open a file
+    pub fn open(path: &str, flags: OpenFlags) -> Result<Self> {
+        let fd = open(path, flags)?;
+        Ok(Self { fd })
+    }
+
+    /// Get the raw file descriptor
+    pub fn fd(&self) -> Fd {
+        self.fd
+    }
+
+    /// Read from the file
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        read(self.fd, buf)
+    }
+
+    /// Write to the file
+    pub fn write(&self, buf: &[u8]) -> Result<usize> {
+        write(self.fd, buf)
+    }
+
+    /// Write all bytes to the file
+    pub fn write_all(&self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            let n = self.write(buf)?;
+            buf = &buf[n..];
+        }
+        Ok(())
+    }
+
+    /// Consume self and return the raw file descriptor without closing
+    pub fn into_raw(self) -> Fd {
+        let fd = self.fd;
+        core::mem::forget(self);
+        fd
+    }
+}
+
+impl Drop for File {
+    fn drop(&mut self) {
+        let _ = close(self.fd);
+    }
+}

--- a/horse_syscall/src/io.rs
+++ b/horse_syscall/src/io.rs
@@ -1,0 +1,182 @@
+//! I/O utilities and standard file descriptors
+//!
+//! This module provides convenient I/O operations for standard streams.
+
+use crate::error::Result;
+use crate::fs::write;
+use crate::raw::Fd;
+use core::fmt;
+
+/// Standard input file descriptor
+pub const STDIN: Fd = 0;
+
+/// Standard output file descriptor
+pub const STDOUT: Fd = 1;
+
+/// Standard error file descriptor
+pub const STDERR: Fd = 2;
+
+/// A writer for standard output
+pub struct Stdout;
+
+impl Stdout {
+    /// Write bytes to stdout
+    pub fn write(&self, buf: &[u8]) -> Result<usize> {
+        write(STDOUT, buf)
+    }
+
+    /// Write all bytes to stdout
+    pub fn write_all(&self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            let n = self.write(buf)?;
+            buf = &buf[n..];
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Write for Stdout {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_all(s.as_bytes()).map_err(|_| fmt::Error)
+    }
+}
+
+/// A writer for standard error
+pub struct Stderr;
+
+impl Stderr {
+    /// Write bytes to stderr
+    pub fn write(&self, buf: &[u8]) -> Result<usize> {
+        write(STDERR, buf)
+    }
+
+    /// Write all bytes to stderr
+    pub fn write_all(&self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            let n = self.write(buf)?;
+            buf = &buf[n..];
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Write for Stderr {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_all(s.as_bytes()).map_err(|_| fmt::Error)
+    }
+}
+
+/// Get a writer for stdout
+pub fn stdout() -> Stdout {
+    Stdout
+}
+
+/// Get a writer for stderr
+pub fn stderr() -> Stderr {
+    Stderr
+}
+
+/// Print a formatted string to stdout
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::io::print;
+///
+/// print("Hello, World!");
+/// ```
+pub fn print(s: &str) {
+    let _ = write(STDOUT, s.as_bytes());
+}
+
+/// Print a formatted string to stdout with a newline
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::io::println;
+///
+/// println("Hello, World!");
+/// ```
+pub fn println(s: &str) {
+    let _ = write(STDOUT, s.as_bytes());
+    let _ = write(STDOUT, b"\n");
+}
+
+/// Print formatted output to stdout
+///
+/// This is similar to the standard `print!` macro but for Horse OS.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::print;
+///
+/// print!("Hello, {}!", "World");
+/// ```
+#[macro_export]
+macro_rules! print {
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        let _ = write!($crate::io::stdout(), $($arg)*);
+    }};
+}
+
+/// Print formatted output to stdout with a newline
+///
+/// This is similar to the standard `println!` macro but for Horse OS.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::println;
+///
+/// println!("Hello, {}!", "World");
+/// ```
+#[macro_export]
+macro_rules! println {
+    () => {
+        $crate::print!("\n")
+    };
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        let _ = writeln!($crate::io::stdout(), $($arg)*);
+    }};
+}
+
+/// Print formatted output to stderr
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::eprint;
+///
+/// eprint!("Error: {}", msg);
+/// ```
+#[macro_export]
+macro_rules! eprint {
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        let _ = write!($crate::io::stderr(), $($arg)*);
+    }};
+}
+
+/// Print formatted output to stderr with a newline
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use horse_syscall::eprintln;
+///
+/// eprintln!("Error: {}", msg);
+/// ```
+#[macro_export]
+macro_rules! eprintln {
+    () => {
+        $crate::eprint!("\n")
+    };
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        let _ = writeln!($crate::io::stderr(), $($arg)*);
+    }};
+}

--- a/horse_syscall/src/lib.rs
+++ b/horse_syscall/src/lib.rs
@@ -1,0 +1,47 @@
+//! # horse_syscall
+//!
+//! System call wrapper library for Horse OS user-space applications.
+//!
+//! This crate provides a safe and ergonomic interface to Horse OS system calls,
+//! allowing `#![no_std]` applications to interact with the kernel.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! #![no_std]
+//! #![no_main]
+//!
+//! use horse_syscall::prelude::*;
+//!
+//! #[no_mangle]
+//! pub extern "C" fn _start() -> ! {
+//!     // Write to stdout
+//!     write(STDOUT, b"Hello from Horse OS!\n").unwrap();
+//!
+//!     // Open and read a file
+//!     let fd = open("/test.txt", OpenFlags::RDONLY).unwrap();
+//!     let mut buf = [0u8; 256];
+//!     let n = read(fd, &mut buf).unwrap();
+//!     close(fd).unwrap();
+//!
+//!     exit(0);
+//! }
+//! ```
+
+#![no_std]
+
+pub mod error;
+pub mod fs;
+pub mod io;
+pub mod raw;
+
+/// Prelude module - import everything you need with `use horse_syscall::prelude::*`
+pub mod prelude {
+    pub use crate::error::{Error, Result};
+    pub use crate::fs::{close, open, read, write, OpenFlags};
+    pub use crate::io::{print, println, STDERR, STDIN, STDOUT};
+    pub use crate::raw::{syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
+}
+
+pub use error::{Error, Result};
+pub use fs::OpenFlags;

--- a/horse_syscall/src/raw.rs
+++ b/horse_syscall/src/raw.rs
@@ -1,0 +1,155 @@
+//! Raw system call interface
+//!
+//! This module provides low-level access to Horse OS system calls using inline assembly.
+//!
+//! ## Calling Convention (x86-64)
+//!
+//! - `RAX`: System call number
+//! - `RDI`: First argument
+//! - `RSI`: Second argument
+//! - `RDX`: Third argument
+//! - `R10`: Fourth argument
+//! - `R8`:  Fifth argument
+//! - `R9`:  Sixth argument
+//! - Return value in `RAX`
+//!
+//! System calls are invoked using `int 0x80`.
+
+use core::arch::asm;
+
+/// System call numbers (Linux-compatible)
+#[repr(usize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyscallNum {
+    /// Read from a file descriptor
+    Read = 0,
+    /// Write to a file descriptor
+    Write = 1,
+    /// Open a file
+    Open = 2,
+    /// Close a file descriptor
+    Close = 3,
+}
+
+/// Perform a system call with no arguments
+#[inline(always)]
+pub unsafe fn syscall0(num: usize) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with one argument
+#[inline(always)]
+pub unsafe fn syscall1(num: usize, arg1: usize) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with two arguments
+#[inline(always)]
+pub unsafe fn syscall2(num: usize, arg1: usize, arg2: usize) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with three arguments
+#[inline(always)]
+pub unsafe fn syscall3(num: usize, arg1: usize, arg2: usize, arg3: usize) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with four arguments
+#[inline(always)]
+pub unsafe fn syscall4(num: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with five arguments
+#[inline(always)]
+pub unsafe fn syscall5(
+    num: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        in("r8") arg5,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+/// Perform a system call with six arguments
+#[inline(always)]
+pub unsafe fn syscall6(
+    num: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) -> isize {
+    let ret: isize;
+    asm!(
+        "int 0x80",
+        inout("rax") num => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        in("r8") arg5,
+        in("r9") arg6,
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+// Convenient type aliases
+pub type Fd = i32;

--- a/kernel/asm.s
+++ b/kernel/asm.s
@@ -184,3 +184,45 @@ syscall_handler_asm:
   pop rbx
 
   iretq
+
+; Jump to user mode
+; fn jump_to_user_mode(entry: u64, user_stack: u64, user_cs: u64, user_ss: u64)
+; Arguments: rdi=entry, rsi=user_stack, rdx=user_cs, rcx=user_ss
+global jump_to_user_mode
+jump_to_user_mode:
+  ; Disable interrupts while setting up
+  cli
+
+  ; Set up data segment registers for user mode
+  mov ax, cx          ; user_ss
+  mov ds, ax
+  mov es, ax
+  mov fs, ax
+  mov gs, ax
+
+  ; Build iretq stack frame
+  push rcx            ; SS (user stack segment)
+  push rsi            ; RSP (user stack pointer)
+  push 0x202          ; RFLAGS (IF=1, reserved bit 1=1)
+  push rdx            ; CS (user code segment)
+  push rdi            ; RIP (entry point)
+
+  ; Clear all general-purpose registers for clean start
+  xor rax, rax
+  xor rbx, rbx
+  xor rcx, rcx
+  xor rdx, rdx
+  xor rsi, rsi
+  xor rdi, rdi
+  xor rbp, rbp
+  xor r8, r8
+  xor r9, r9
+  xor r10, r10
+  xor r11, r11
+  xor r12, r12
+  xor r13, r13
+  xor r14, r14
+  xor r15, r15
+
+  ; Jump to user mode!
+  iretq

--- a/kernel/src/drivers/detect_dev.rs
+++ b/kernel/src/drivers/detect_dev.rs
@@ -41,6 +41,7 @@ pub fn initialize_pci_devices(pci_devices: &PciDevices) -> Option<Controller> {
             // Display Controller
             0x03 => match dev.get_vendor_id() {
                 0x1234 => {
+/*
                     let resolution = setup_qemu_card(&dev);
                     let mut graphics_lock = RAW_GRAPHICS.lock();
                     let graphics = match graphics_lock.as_mut() {
@@ -49,6 +50,7 @@ pub fn initialize_pci_devices(pci_devices: &PciDevices) -> Option<Controller> {
                     };
                     unsafe { graphics.change_resolution(resolution) };
                     graphics.clear(&BG_COLOR);
+*/
                 }
                 _ => {
                     info!(

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -1,0 +1,276 @@
+//! ELF (Executable and Linkable Format) loader
+//!
+//! This module provides functionality to parse and load ELF64 executables
+//! for user-space program execution.
+
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+/// ELF magic number
+pub const ELF_MAGIC: [u8; 4] = [0x7f, b'E', b'L', b'F'];
+
+/// ELF class: 64-bit
+pub const ELFCLASS64: u8 = 2;
+
+/// ELF data encoding: little endian
+pub const ELFDATA2LSB: u8 = 1;
+
+/// ELF type: executable
+pub const ET_EXEC: u16 = 2;
+
+/// ELF machine: x86-64
+pub const EM_X86_64: u16 = 62;
+
+/// Program header type: loadable segment
+pub const PT_LOAD: u32 = 1;
+
+/// Program header flags
+pub const PF_X: u32 = 1; // Execute
+pub const PF_W: u32 = 2; // Write
+pub const PF_R: u32 = 4; // Read
+
+/// ELF64 file header
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct Elf64Header {
+    /// Magic number and other info
+    pub e_ident: [u8; 16],
+    /// Object file type
+    pub e_type: u16,
+    /// Architecture
+    pub e_machine: u16,
+    /// Object file version
+    pub e_version: u32,
+    /// Entry point virtual address
+    pub e_entry: u64,
+    /// Program header table file offset
+    pub e_phoff: u64,
+    /// Section header table file offset
+    pub e_shoff: u64,
+    /// Processor-specific flags
+    pub e_flags: u32,
+    /// ELF header size in bytes
+    pub e_ehsize: u16,
+    /// Program header table entry size
+    pub e_phentsize: u16,
+    /// Program header table entry count
+    pub e_phnum: u16,
+    /// Section header table entry size
+    pub e_shentsize: u16,
+    /// Section header table entry count
+    pub e_shnum: u16,
+    /// Section header string table index
+    pub e_shstrndx: u16,
+}
+
+impl Elf64Header {
+    /// Check if this is a valid ELF64 executable for x86-64
+    pub fn is_valid(&self) -> bool {
+        // Check magic number
+        if self.e_ident[0..4] != ELF_MAGIC {
+            return false;
+        }
+        // Check 64-bit
+        if self.e_ident[4] != ELFCLASS64 {
+            return false;
+        }
+        // Check little endian
+        if self.e_ident[5] != ELFDATA2LSB {
+            return false;
+        }
+        // Check executable type
+        if self.e_type != ET_EXEC {
+            return false;
+        }
+        // Check x86-64 architecture
+        if self.e_machine != EM_X86_64 {
+            return false;
+        }
+        true
+    }
+}
+
+/// ELF64 program header
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct Elf64ProgramHeader {
+    /// Segment type
+    pub p_type: u32,
+    /// Segment flags
+    pub p_flags: u32,
+    /// Segment file offset
+    pub p_offset: u64,
+    /// Segment virtual address
+    pub p_vaddr: u64,
+    /// Segment physical address
+    pub p_paddr: u64,
+    /// Segment size in file
+    pub p_filesz: u64,
+    /// Segment size in memory
+    pub p_memsz: u64,
+    /// Segment alignment
+    pub p_align: u64,
+}
+
+/// Parsed ELF information
+#[derive(Debug)]
+pub struct ElfInfo {
+    /// Entry point address
+    pub entry_point: u64,
+    /// Loadable segments
+    pub segments: Vec<LoadSegment>,
+    /// Lowest virtual address (for memory allocation)
+    pub load_base: u64,
+    /// Highest virtual address + size (for memory allocation)
+    pub load_end: u64,
+}
+
+/// A segment to be loaded into memory
+#[derive(Debug, Clone)]
+pub struct LoadSegment {
+    /// Virtual address to load at
+    pub vaddr: u64,
+    /// Physical address
+    pub paddr: u64,
+    /// Offset in the file
+    pub file_offset: u64,
+    /// Size in the file
+    pub file_size: u64,
+    /// Size in memory (may be larger than file_size for .bss)
+    pub mem_size: u64,
+    /// Flags (readable, writable, executable)
+    pub flags: u32,
+}
+
+/// ELF parsing error
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElfError {
+    /// Invalid ELF magic number
+    InvalidMagic,
+    /// Not a 64-bit ELF
+    Not64Bit,
+    /// Not little endian
+    NotLittleEndian,
+    /// Not an executable
+    NotExecutable,
+    /// Wrong architecture
+    WrongArchitecture,
+    /// File too small
+    FileTooSmall,
+    /// Invalid program header
+    InvalidProgramHeader,
+}
+
+/// Parse an ELF64 executable from raw bytes
+pub fn parse_elf(data: &[u8]) -> Result<ElfInfo, ElfError> {
+    // Check minimum size for ELF header
+    if data.len() < size_of::<Elf64Header>() {
+        return Err(ElfError::FileTooSmall);
+    }
+
+    // Parse ELF header
+    let header = unsafe { &*(data.as_ptr() as *const Elf64Header) };
+
+    // Validate header
+    if header.e_ident[0..4] != ELF_MAGIC {
+        return Err(ElfError::InvalidMagic);
+    }
+    if header.e_ident[4] != ELFCLASS64 {
+        return Err(ElfError::Not64Bit);
+    }
+    if header.e_ident[5] != ELFDATA2LSB {
+        return Err(ElfError::NotLittleEndian);
+    }
+    if header.e_type != ET_EXEC {
+        return Err(ElfError::NotExecutable);
+    }
+    if header.e_machine != EM_X86_64 {
+        return Err(ElfError::WrongArchitecture);
+    }
+
+    let entry_point = header.e_entry;
+    let ph_offset = header.e_phoff as usize;
+    let ph_size = header.e_phentsize as usize;
+    let ph_num = header.e_phnum as usize;
+
+    // Parse program headers
+    let mut segments = Vec::new();
+    let mut load_base = u64::MAX;
+    let mut load_end = 0u64;
+
+    for i in 0..ph_num {
+        let ph_start = ph_offset + i * ph_size;
+        if ph_start + size_of::<Elf64ProgramHeader>() > data.len() {
+            return Err(ElfError::InvalidProgramHeader);
+        }
+
+        let ph = unsafe { &*(data.as_ptr().add(ph_start) as *const Elf64ProgramHeader) };
+
+        // Only process loadable segments
+        if ph.p_type == PT_LOAD {
+            let vaddr = ph.p_vaddr;
+            let memsz = ph.p_memsz;
+
+            // Track memory bounds
+            if vaddr < load_base {
+                load_base = vaddr;
+            }
+            if vaddr + memsz > load_end {
+                load_end = vaddr + memsz;
+            }
+
+            segments.push(LoadSegment {
+                vaddr: ph.p_vaddr,
+                paddr: ph.p_paddr,
+                file_offset: ph.p_offset,
+                file_size: ph.p_filesz,
+                mem_size: ph.p_memsz,
+                flags: ph.p_flags,
+            });
+        }
+    }
+
+    if load_base == u64::MAX {
+        load_base = 0;
+    }
+
+    Ok(ElfInfo {
+        entry_point,
+        segments,
+        load_base,
+        load_end,
+    })
+}
+
+/// Load ELF segments into memory
+///
+/// This function copies the loadable segments from the ELF file to the
+/// specified memory regions. The caller is responsible for allocating
+/// the memory at the correct virtual addresses.
+///
+/// # Safety
+///
+/// The destination memory must be valid and properly allocated.
+pub unsafe fn load_segments(elf_data: &[u8], elf_info: &ElfInfo, base_addr: *mut u8) {
+    for segment in &elf_info.segments {
+        let dest = base_addr.add((segment.vaddr - elf_info.load_base) as usize);
+        let src = elf_data.as_ptr().add(segment.file_offset as usize);
+
+        // Copy file content
+        if segment.file_size > 0 {
+            core::ptr::copy_nonoverlapping(src, dest, segment.file_size as usize);
+        }
+
+        // Zero out the rest (for .bss section)
+        if segment.mem_size > segment.file_size {
+            let bss_start = dest.add(segment.file_size as usize);
+            let bss_size = (segment.mem_size - segment.file_size) as usize;
+            core::ptr::write_bytes(bss_start, 0, bss_size);
+        }
+    }
+}
+
+/// Calculate the total memory size needed for the ELF
+pub fn calculate_memory_size(elf_info: &ElfInfo) -> usize {
+    (elf_info.load_end - elf_info.load_base) as usize
+}

--- a/kernel/src/exec.rs
+++ b/kernel/src/exec.rs
@@ -1,0 +1,166 @@
+//! User program execution
+//!
+//! This module provides functionality to load and execute user-space programs.
+
+use crate::elf::{parse_elf, load_segments, calculate_memory_size, ElfError};
+use crate::segment::{USER_CS, USER_SS};
+
+/// Default user stack size (64 KB)
+const USER_STACK_SIZE: usize = 64 * 1024;
+
+/// User stack base address (below kernel space)
+/// In a real OS, this would be determined by the process's virtual address space
+const USER_STACK_BASE: u64 = 0x0000_7fff_ffff_0000;
+
+// External assembly function to jump to user mode
+extern "C" {
+    fn jump_to_user_mode(entry: u64, user_stack: u64, user_cs: u64, user_ss: u64) -> !;
+}
+
+/// Error type for program execution
+#[derive(Debug, Clone, Copy)]
+pub enum ExecError {
+    /// ELF parsing error
+    ElfError(ElfError),
+    /// Memory allocation failed
+    MemoryAllocationFailed,
+    /// Stack allocation failed
+    StackAllocationFailed,
+}
+
+impl From<ElfError> for ExecError {
+    fn from(e: ElfError) -> Self {
+        ExecError::ElfError(e)
+    }
+}
+
+/// Loaded program ready for execution
+pub struct LoadedProgram {
+    /// Entry point address
+    pub entry_point: u64,
+    /// Base address where program was loaded
+    pub load_base: u64,
+    /// Size of loaded program
+    pub load_size: usize,
+    /// User stack pointer (top of stack)
+    pub stack_pointer: u64,
+    /// User stack base (bottom of stack)
+    pub stack_base: u64,
+    /// User stack size
+    pub stack_size: usize,
+}
+
+/// Load an ELF program into memory
+///
+/// This function parses the ELF file, allocates memory, and loads the program
+/// segments into memory. It also allocates a user stack.
+///
+/// # Arguments
+///
+/// * `elf_data` - The raw ELF file data
+///
+/// # Returns
+///
+/// * `Ok(LoadedProgram)` - Information about the loaded program
+/// * `Err(ExecError)` - Error if loading failed
+pub fn load_program(elf_data: &[u8]) -> Result<LoadedProgram, ExecError> {
+    // Parse ELF
+    let elf_info = parse_elf(elf_data)?;
+
+    crate::debug!("ELF parsed: entry=0x{:x}, load_base=0x{:x}, load_end=0x{:x}",
+        elf_info.entry_point, elf_info.load_base, elf_info.load_end);
+
+    // Calculate memory needed
+    let program_size = calculate_memory_size(&elf_info);
+
+    // For simplicity, we'll load the program at its specified virtual address
+    // In a real OS, we would set up page tables for the process
+    let load_base = elf_info.load_base;
+
+    // Load segments
+    unsafe {
+        load_segments(elf_data, &elf_info, load_base as *mut u8);
+    }
+
+    crate::debug!("Program loaded at 0x{:x}, size={} bytes", load_base, program_size);
+
+    // Allocate user stack
+    // For simplicity, we use a fixed stack address
+    // In a real OS, this would be allocated per-process
+    let stack_base = USER_STACK_BASE - USER_STACK_SIZE as u64;
+    let stack_top = USER_STACK_BASE;
+
+    // The stack pointer starts at the top and grows downward
+    // Align to 16 bytes as required by System V AMD64 ABI
+    let stack_pointer = stack_top & !0xF;
+
+    crate::debug!("User stack: base=0x{:x}, top=0x{:x}, sp=0x{:x}",
+        stack_base, stack_top, stack_pointer);
+
+    Ok(LoadedProgram {
+        entry_point: elf_info.entry_point,
+        load_base,
+        load_size: program_size,
+        stack_pointer,
+        stack_base,
+        stack_size: USER_STACK_SIZE,
+    })
+}
+
+/// Execute a loaded program
+///
+/// This function transitions to user mode and starts executing the program.
+/// **This function never returns!**
+///
+/// # Arguments
+///
+/// * `program` - The loaded program to execute
+///
+/// # Safety
+///
+/// This function is unsafe because it transitions to user mode and
+/// the program must be properly loaded.
+pub unsafe fn execute_program(program: &LoadedProgram) -> ! {
+    crate::info!("Executing program at 0x{:x}", program.entry_point);
+
+    // Jump to user mode
+    jump_to_user_mode(
+        program.entry_point,
+        program.stack_pointer,
+        USER_CS as u64,
+        USER_SS as u64,
+    )
+}
+
+/// Load and execute an ELF program
+///
+/// This is a convenience function that combines loading and execution.
+/// **This function never returns!**
+///
+/// # Arguments
+///
+/// * `elf_data` - The raw ELF file data
+pub fn exec(elf_data: &[u8]) -> Result<!, ExecError> {
+    let program = load_program(elf_data)?;
+    unsafe {
+        execute_program(&program)
+    }
+}
+
+/// Simple execution function for testing
+///
+/// Loads an ELF from the given data and executes it.
+/// Prints error message if loading fails.
+pub fn run_elf(elf_data: &[u8]) {
+    match load_program(elf_data) {
+        Ok(program) => {
+            crate::info!("Starting user program...");
+            unsafe {
+                execute_program(&program);
+            }
+        }
+        Err(e) => {
+            crate::error!("Failed to load program: {:?}", e);
+        }
+    }
+}

--- a/kernel/src/horse_lib/bytes.rs
+++ b/kernel/src/horse_lib/bytes.rs
@@ -10,7 +10,9 @@ const CRC32_POLYNOMIAL: u32 = 0xedb88320;
 static CRC_TABLE: Once<[u32; 256]> = Once::new();
 
 pub fn bytes2str(bytes: &[u8]) -> String {
-    return String::from_utf8(bytes.to_vec()).unwrap();
+    // Use lossy conversion to handle invalid UTF-8 gracefully
+    // FAT32 LFN entries are UTF-16LE, so we need special handling
+    String::from_utf8_lossy(bytes).into_owned()
 }
 
 pub fn sum_bytes<T>(data: &T, len: usize) -> u8 {

--- a/kernel/src/horse_lib/fd.rs
+++ b/kernel/src/horse_lib/fd.rs
@@ -21,7 +21,14 @@ pub struct Path {
 
 impl Path {
     pub fn new(full_path: String)  -> Self {
-        return Self { path: full_path.split('/').map(|s| s.to_string()).collect() }
+        // Handle both / and \ as path separators, and filter out empty components
+        let path: Vec<String> = full_path
+            .replace('\\', "/")
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        return Self { path }
     }
     pub fn path_iter(&self) -> Vec<String> {
         return self.path.clone()

--- a/kernel/src/horse_lib/fd.rs
+++ b/kernel/src/horse_lib/fd.rs
@@ -21,7 +21,13 @@ pub struct Path {
 
 impl Path {
     pub fn new(full_path: String)  -> Self {
-        return Self { path: full_path.split('/').map(|s| s.to_string()).collect() }
+        // Filter out empty components from leading/trailing slashes
+        let path: Vec<String> = full_path
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        return Self { path }
     }
     pub fn path_iter(&self) -> Vec<String> {
         return self.path.clone()

--- a/kernel/src/horse_lib/fd.rs
+++ b/kernel/src/horse_lib/fd.rs
@@ -21,14 +21,7 @@ pub struct Path {
 
 impl Path {
     pub fn new(full_path: String)  -> Self {
-        // Handle both / and \ as path separators, and filter out empty components
-        let path: Vec<String> = full_path
-            .replace('\\', "/")
-            .split('/')
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .collect();
-        return Self { path }
+        return Self { path: full_path.split('/').map(|s| s.to_string()).collect() }
     }
     pub fn path_iter(&self) -> Vec<String> {
         return self.path.clone()

--- a/kernel/src/interrupt.rs
+++ b/kernel/src/interrupt.rs
@@ -4,12 +4,19 @@ pub use x86_64::structures::idt::InterruptDescriptorTable;
 
 pub static IDT: Mutex<InterruptDescriptorTable> = Mutex::new(InterruptDescriptorTable::new());
 
+#[repr(usize)]
 pub enum InterruptVector {
     Xhci = 0x40,
     LAPICTimer = 0x41,
+    Syscall = 0x80,
 }
 
 pub unsafe fn notify_end_of_interrupt() {
     let end_of_interrupt: *mut u32 = 0xfee000b0 as *mut u32;
     write_volatile(end_of_interrupt, 0);
+}
+
+// Assembly syscall handler
+extern "C" {
+    pub fn syscall_handler_asm();
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -113,18 +113,10 @@ fn run_gallop() {
 
     // Try to open the gallop file from the root of the filesystem
     let fs = &fs_table[0];
-    let mut fd = fs.open("\\gallop", 0); // FAT32 uses backslash paths
+    let fd = fs.open("/gallop", 0);
     if fd < 0 {
-        // Try alternative path
-        fd = fs.open("/gallop", 0);
-        if fd < 0 {
-            // Try uppercase filename (FAT32 often uppercases)
-            fd = fs.open("\\GALLOP", 0);
-            if fd < 0 {
-                error!("Failed to open gallop: fd={}", fd);
-                return;
-            }
-        }
+        error!("Failed to open gallop: fd={}", fd);
+        return;
     }
 
     // Read the ELF file into a buffer

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -2,6 +2,7 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 #![feature(core_intrinsics)]
+#![feature(never_type)]
 
 mod acpi;
 mod ascii_font;
@@ -12,6 +13,8 @@ mod segment;
 mod syscall;
 
 pub mod console;
+pub mod elf;
+pub mod exec;
 pub mod drivers;
 pub mod fixed_vec;
 pub mod framebuffer;

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,0 +1,288 @@
+//! System Call implementation for Horse OS
+//!
+//! This module provides the syscall interface for user-space applications.
+//!
+//! Syscall calling convention (x86-64):
+//! - RAX: syscall number
+//! - RDI: arg1
+//! - RSI: arg2
+//! - RDX: arg3
+//! - R10: arg4
+//! - R8:  arg5
+//! - R9:  arg6
+//! - Return value in RAX
+
+use alloc::vec;
+use crate::drivers::fs::init::FILESYSTEM_TABLE;
+use crate::console::Console;
+
+/// System call numbers (Linux-compatible)
+#[repr(usize)]
+#[derive(Debug, Clone, Copy)]
+pub enum SyscallNumber {
+    Read = 0,
+    Write = 1,
+    Open = 2,
+    Close = 3,
+}
+
+impl TryFrom<usize> for SyscallNumber {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(SyscallNumber::Read),
+            1 => Ok(SyscallNumber::Write),
+            2 => Ok(SyscallNumber::Open),
+            3 => Ok(SyscallNumber::Close),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Syscall error codes
+#[repr(isize)]
+#[derive(Debug, Clone, Copy)]
+pub enum SyscallError {
+    InvalidSyscall = -1,
+    InvalidFd = -9,      // EBADF
+    InvalidArg = -22,    // EINVAL
+    NoEnt = -2,          // ENOENT
+    IoError = -5,        // EIO
+}
+
+/// Syscall arguments structure
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct SyscallArgs {
+    pub syscall_num: usize,
+    pub arg1: usize,
+    pub arg2: usize,
+    pub arg3: usize,
+    pub arg4: usize,
+    pub arg5: usize,
+    pub arg6: usize,
+}
+
+/// Main syscall dispatcher
+///
+/// Called from the syscall interrupt handler with saved register state
+pub fn syscall_handler(args: &SyscallArgs) -> isize {
+    let syscall_num = match SyscallNumber::try_from(args.syscall_num) {
+        Ok(num) => num,
+        Err(_) => return SyscallError::InvalidSyscall as isize,
+    };
+
+    match syscall_num {
+        SyscallNumber::Read => sys_read(
+            args.arg1 as i32,       // fd
+            args.arg2 as *mut u8,   // buf
+            args.arg3,              // count
+        ),
+        SyscallNumber::Write => sys_write(
+            args.arg1 as i32,       // fd
+            args.arg2 as *const u8, // buf
+            args.arg3,              // count
+        ),
+        SyscallNumber::Open => sys_open(
+            args.arg1 as *const u8, // pathname
+            args.arg2 as u32,       // flags
+        ),
+        SyscallNumber::Close => sys_close(args.arg1 as i32),
+    }
+}
+
+/// sys_open - Open a file
+///
+/// # Arguments
+/// * `pathname` - Pointer to null-terminated pathname string
+/// * `flags` - Open flags (O_RDONLY, O_WRONLY, O_RDWR, O_CREAT)
+///
+/// # Returns
+/// * File descriptor on success (>= 0)
+/// * Negative error code on failure
+pub fn sys_open(pathname: *const u8, flags: u32) -> isize {
+    if pathname.is_null() {
+        return SyscallError::InvalidArg as isize;
+    }
+
+    // Read the pathname from user space
+    let path_str = unsafe {
+        let mut len = 0;
+        let mut ptr = pathname;
+        while *ptr != 0 {
+            len += 1;
+            ptr = ptr.add(1);
+            if len > 4096 {
+                return SyscallError::InvalidArg as isize;
+            }
+        }
+        let slice = core::slice::from_raw_parts(pathname, len);
+        match core::str::from_utf8(slice) {
+            Ok(s) => s,
+            Err(_) => return SyscallError::InvalidArg as isize,
+        }
+    };
+
+    // Use the filesystem to open the file
+    // Safety: FILESYSTEM_TABLE is initialized once at boot
+    let fs_table = unsafe { FILESYSTEM_TABLE.lock() };
+    if !fs_table.is_empty() {
+        let fd = fs_table[0].open(path_str, flags);
+        if fd < 0 {
+            return SyscallError::NoEnt as isize;
+        }
+        return fd as isize;
+    }
+
+    SyscallError::IoError as isize
+}
+
+/// sys_read - Read from a file descriptor
+///
+/// # Arguments
+/// * `fd` - File descriptor
+/// * `buf` - Buffer to read into
+/// * `count` - Number of bytes to read
+///
+/// # Returns
+/// * Number of bytes read on success (>= 0)
+/// * Negative error code on failure
+pub fn sys_read(fd: i32, buf: *mut u8, count: usize) -> isize {
+    if buf.is_null() || count == 0 {
+        return SyscallError::InvalidArg as isize;
+    }
+
+    // Validate file descriptor
+    if fd < 0 {
+        return SyscallError::InvalidFd as isize;
+    }
+
+    // Handle stdin (fd 0)
+    if fd == 0 {
+        // For now, stdin reading is not implemented
+        // Could integrate with keyboard driver in the future
+        return 0;
+    }
+
+    // For regular files, use filesystem
+    // Safety: FILESYSTEM_TABLE is initialized once at boot
+    let fs_table = unsafe { FILESYSTEM_TABLE.lock() };
+    if !fs_table.is_empty() {
+        let mut temp_buf = vec![0u8; count];
+        let bytes_read = fs_table[0].read(fd, &mut temp_buf, count);
+
+        if bytes_read < 0 {
+            return SyscallError::IoError as isize;
+        }
+
+        // Copy to user buffer
+        unsafe {
+            core::ptr::copy_nonoverlapping(temp_buf.as_ptr(), buf, bytes_read as usize);
+        }
+
+        return bytes_read;
+    }
+
+    SyscallError::IoError as isize
+}
+
+/// sys_write - Write to a file descriptor
+///
+/// # Arguments
+/// * `fd` - File descriptor
+/// * `buf` - Buffer to write from
+/// * `count` - Number of bytes to write
+///
+/// # Returns
+/// * Number of bytes written on success (>= 0)
+/// * Negative error code on failure
+pub fn sys_write(fd: i32, buf: *const u8, count: usize) -> isize {
+    if buf.is_null() || count == 0 {
+        return SyscallError::InvalidArg as isize;
+    }
+
+    // Validate file descriptor
+    if fd < 0 {
+        return SyscallError::InvalidFd as isize;
+    }
+
+    // Handle stdout (fd 1) and stderr (fd 2)
+    if fd == 1 || fd == 2 {
+        let data = unsafe {
+            core::slice::from_raw_parts(buf, count)
+        };
+
+        // Convert to string and print
+        if let Ok(s) = core::str::from_utf8(data) {
+            // Write to console
+            let mut console = Console::instance();
+            if let Some(ref mut con) = *console {
+                con.put_string(s);
+            }
+            return count as isize;
+        } else {
+            // Write raw bytes as characters (convert each byte to a char string)
+            let mut console = Console::instance();
+            if let Some(ref mut con) = *console {
+                for &byte in data {
+                    // Create a temporary buffer for single character
+                    let mut buf = [0u8; 4];
+                    let c = byte as char;
+                    if let Some(s) = c.encode_utf8(&mut buf).get(..c.len_utf8()) {
+                        con.put_string(s);
+                    }
+                }
+            }
+            return count as isize;
+        }
+    }
+
+    // For regular files, write is not yet implemented in FAT
+    // Return error for now
+    SyscallError::IoError as isize
+}
+
+/// sys_close - Close a file descriptor
+///
+/// # Arguments
+/// * `fd` - File descriptor to close
+///
+/// # Returns
+/// * 0 on success
+/// * Negative error code on failure
+pub fn sys_close(fd: i32) -> isize {
+    // Validate file descriptor
+    if fd < 0 {
+        return SyscallError::InvalidFd as isize;
+    }
+
+    // Don't close stdin, stdout, stderr
+    if fd <= 2 {
+        return 0;
+    }
+
+    // Use filesystem to close
+    // Safety: FILESYSTEM_TABLE is initialized once at boot
+    let fs_table = unsafe { FILESYSTEM_TABLE.lock() };
+    if !fs_table.is_empty() {
+        fs_table[0].close(fd);
+        return 0;
+    }
+
+    SyscallError::IoError as isize
+}
+
+/// Entry point for syscall from assembly
+///
+/// This function is called from the assembly interrupt handler (syscall_handler_asm)
+/// with a pointer to the SyscallArgs structure on the stack.
+#[no_mangle]
+pub extern "C" fn syscall_entry(args: *const SyscallArgs) -> isize {
+    if args.is_null() {
+        return SyscallError::InvalidArg as isize;
+    }
+
+    let args_ref = unsafe { &*args };
+    syscall_handler(args_ref)
+}


### PR DESCRIPTION
# Summary

This PR implements a complete system call infrastructure for Horse OS, enabling user-space program execution.
New Features

## System Call Implementation (kernel/src/syscall.rs)
- Implemented basic syscalls: open, read, write, close
- Linux-compatible syscall numbers (0, 1, 2, 3)
- Uses int 0x80 software interrupt with x86-64 calling convention

## User-Space Library (horse_syscall/)
- Created horse_syscall crate with syscall wrappers for no_std programs
- Provides print!/println! macros via syscalls
- Raw syscall interface (syscall0 through syscall6)

## User Mode Transition (kernel/src/exec.rs, kernel/src/elf.rs)
- ELF64 parser for x86-64 executables
- Ring 0 to Ring 3 transition via iretq
- User segment descriptors (USER_CS, USER_SS) with DPL=3

## initial program for initial process (gallop/)
- Hello World user-space program using horse_syscall
- Custom target specification for bare-metal x86-64
- Integrated into build system and executed on boot

## Bug Fixes
- Set syscall IDT entry DPL=3 to allow user mode invocation
- Fix bytes2str panic on non-UTF8 bytes (FAT32 LFN entries)
- Handle find_file errors gracefully instead of panicking
- Filter empty path components in Path::new for correct file lookup
