### PR TITLE
Claude/implement exit syscall tc i81

### DIFF
--- a/gallop/src/main.rs
+++ b/gallop/src/main.rs
@@ -24,12 +24,8 @@ pub extern "C" fn _start() -> ! {
     // Use write syscall instead for debug output
     let _ = write(STDOUT, b"Syscall returned successfully!\n");
 
-    // Since we don't have an exit syscall yet, loop forever
-    // In a real program, you would call exit(0) here
-    loop {
-        // Hint to the CPU that we're in a spin loop
-        core::hint::spin_loop();
-    }
+    // Exit the process with status code 0 (success)
+    exit(0);
 }
 
 /// Panic handler

--- a/horse_syscall/src/fs.rs
+++ b/horse_syscall/src/fs.rs
@@ -5,6 +5,25 @@
 use crate::error::{check_syscall, Result};
 use crate::raw::{syscall1, syscall2, syscall3, Fd, SyscallNum};
 
+/// Exit the process
+///
+/// # Arguments
+///
+/// * `status` - Exit status code (0 for success, non-zero for error)
+///
+/// # Note
+///
+/// This function never returns.
+pub fn exit(status: i32) -> ! {
+    unsafe {
+        syscall1(SyscallNum::Exit as usize, status as usize);
+    }
+    // Should never reach here, but loop forever just in case
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
 /// File open flags
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OpenFlags(u32);

--- a/horse_syscall/src/lib.rs
+++ b/horse_syscall/src/lib.rs
@@ -38,7 +38,7 @@ pub mod raw;
 /// Prelude module - import everything you need with `use horse_syscall::prelude::*`
 pub mod prelude {
     pub use crate::error::{Error, Result};
-    pub use crate::fs::{close, open, read, write, OpenFlags};
+    pub use crate::fs::{close, exit, open, read, write, OpenFlags};
     pub use crate::io::{print, println, STDERR, STDIN, STDOUT};
     pub use crate::raw::{syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
 }

--- a/horse_syscall/src/raw.rs
+++ b/horse_syscall/src/raw.rs
@@ -29,6 +29,8 @@ pub enum SyscallNum {
     Open = 2,
     /// Close a file descriptor
     Close = 3,
+    /// Exit the process
+    Exit = 60,
 }
 
 /// Perform a system call with no arguments

--- a/kernel/src/debugcon.rs
+++ b/kernel/src/debugcon.rs
@@ -1,0 +1,101 @@
+//! Debugcon output module for QEMU debug output
+//!
+//! This module provides functions to output debug information to QEMU's debugcon
+//! port (0xE9). Use `-debugcon stdio` or `-debugcon file:debug.log` when running QEMU.
+
+/// Debugcon port for QEMU debug output (0xE9)
+const DEBUGCON_PORT: u16 = 0xE9;
+
+/// Write a single byte to debugcon
+#[inline]
+pub fn write_byte(byte: u8) {
+    unsafe {
+        core::arch::asm!(
+            "out dx, al",
+            in("dx") DEBUGCON_PORT,
+            in("al") byte,
+            options(nostack, preserves_flags)
+        );
+    }
+}
+
+/// Write a string to debugcon
+pub fn write_str(s: &str) {
+    for byte in s.bytes() {
+        write_byte(byte);
+    }
+}
+
+/// Write a hex number to debugcon
+pub fn write_hex(value: u64) {
+    write_str("0x");
+    for i in (0..16).rev() {
+        let nibble = ((value >> (i * 4)) & 0xF) as u8;
+        let c = if nibble < 10 {
+            b'0' + nibble
+        } else {
+            b'a' + nibble - 10
+        };
+        write_byte(c);
+    }
+}
+
+/// Write a decimal number to debugcon
+pub fn write_dec(mut value: u64) {
+    if value == 0 {
+        write_byte(b'0');
+        return;
+    }
+
+    let mut buf = [0u8; 20]; // u64 max is 20 digits
+    let mut i = 0;
+
+    while value > 0 {
+        buf[i] = b'0' + (value % 10) as u8;
+        value /= 10;
+        i += 1;
+    }
+
+    // Print in reverse order
+    while i > 0 {
+        i -= 1;
+        write_byte(buf[i]);
+    }
+}
+
+/// Write a newline to debugcon
+#[inline]
+pub fn write_newline() {
+    write_byte(b'\n');
+}
+
+/// Macro for formatted debugcon output (similar to print!)
+#[macro_export]
+macro_rules! debugcon_print {
+    ($($arg:tt)*) => {{
+        use core::fmt::Write;
+        let _ = write!($crate::debugcon::DebugconWriter, $($arg)*);
+    }};
+}
+
+/// Macro for formatted debugcon output with newline (similar to println!)
+#[macro_export]
+macro_rules! debugcon_println {
+    () => {
+        $crate::debugcon::write_newline();
+    };
+    ($($arg:tt)*) => {{
+        $crate::debugcon_print!($($arg)*);
+        $crate::debugcon::write_newline();
+    }};
+}
+
+/// Writer struct for core::fmt::Write implementation
+pub struct DebugconWriter;
+
+impl core::fmt::Write for DebugconWriter {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        write_str(s);
+        Ok(())
+    }
+}

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -344,9 +344,16 @@ impl PageTableManager {
         let pml4 = phys_to_ptr::<PageTable>(phys);
 
         unsafe {
+            // Copy kernel mappings from kernel page table
+            let kernel_pml4 = addr_of!(KERNEL_PML4);
+
+            // Copy lower half identity mapping (PML4[0])
+            // This is needed because ProcessContext and other kernel data structures
+            // are in this region, and switch_context accesses them after CR3 switch
+            (*pml4).entries[0] = (*kernel_pml4).entries[0];
+
             // Copy higher half kernel mappings (PML4[511])
             // This ensures kernel code/data is accessible when switching to kernel mode
-            let kernel_pml4 = addr_of!(KERNEL_PML4);
             (*pml4).entries[KERNEL_PML4_INDEX] = (*kernel_pml4).entries[KERNEL_PML4_INDEX];
         }
 

--- a/kernel/src/paging.rs
+++ b/kernel/src/paging.rs
@@ -89,6 +89,11 @@ impl PageTableFlags {
     pub const fn intersection(self, other: Self) -> Self {
         Self(self.0 & other.0)
     }
+
+    /// Remove flags from self (self & !other)
+    pub const fn difference(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
 }
 
 impl core::ops::BitOr for PageTableFlags {
@@ -338,22 +343,52 @@ impl PageTableManager {
     /// Create a new user page table with kernel mappings
     /// Returns (physical_address, virtual_pointer)
     pub fn create_user_page_table(&self) -> Option<(u64, *mut PageTable)> {
-        use core::ptr::addr_of;
-
         let phys = self.allocate_page_table_phys()?;
         let pml4 = phys_to_ptr::<PageTable>(phys);
 
         unsafe {
             // Copy kernel mappings from kernel page table
-            let kernel_pml4 = addr_of!(KERNEL_PML4);
+            let kernel_pml4 = core::ptr::addr_of!(KERNEL_PML4);
 
-            // Copy lower half identity mapping (PML4[0])
-            // This is needed because ProcessContext and other kernel data structures
-            // are in this region, and switch_context accesses them after CR3 switch
-            (*pml4).entries[0] = (*kernel_pml4).entries[0];
+            // For PML4[0] (low addresses where user programs live), we need to create
+            // a COPY of the page table hierarchy, not just copy the pointer.
+            // This is because we may need to modify entries (e.g., split huge pages)
+            // without affecting the kernel's page tables.
+            let kernel_pml4_0 = (*kernel_pml4).entries[0];
+            if kernel_pml4_0.is_present() {
+                // Create a new PDPT for this user process
+                let user_pdpt_phys = self.allocate_page_table_phys()?;
+                let user_pdpt = phys_to_ptr::<PageTable>(user_pdpt_phys);
+                
+                // Copy entries from kernel's PDPT
+                let kernel_pdpt = phys_to_ptr::<PageTable>(kernel_pml4_0.addr());
+                for i in 0..PAGE_TABLE_ENTRIES {
+                    let kernel_pdpt_entry = (*kernel_pdpt).entries[i];
+                    if kernel_pdpt_entry.is_present() {
+                        // Create a new PD for this PDPT entry
+                        let user_pd_phys = self.allocate_page_table_phys()?;
+                        let user_pd = phys_to_ptr::<PageTable>(user_pd_phys);
+                        
+                        // Copy PD entries from kernel
+                        let kernel_pd = phys_to_ptr::<PageTable>(kernel_pdpt_entry.addr());
+                        core::ptr::copy_nonoverlapping(
+                            (*kernel_pd).entries.as_ptr(),
+                            (*user_pd).entries.as_mut_ptr(),
+                            PAGE_TABLE_ENTRIES,
+                        );
+                        
+                        // Set user PDPT entry to point to copied PD
+                        (*user_pdpt).entries[i].set(user_pd_phys, kernel_pdpt_entry.flags());
+                    }
+                }
+                
+                // Set user PML4[0] to point to new PDPT
+                (*pml4).entries[0].set(user_pdpt_phys, kernel_pml4_0.flags());
+            }
 
             // Copy higher half kernel mappings (PML4[511])
             // This ensures kernel code/data is accessible when switching to kernel mode
+            // We can share this directly since user code won't modify kernel mappings
             (*pml4).entries[KERNEL_PML4_INDEX] = (*kernel_pml4).entries[KERNEL_PML4_INDEX];
         }
 
@@ -379,9 +414,17 @@ impl PageTableManager {
             let pdpt_ref = &mut *pdpt;
             let pd = self.get_or_create_table(&mut pdpt_ref.entries[vaddr.pdpt_index()], flags)?;
 
-            // Get or create PT
+            // Check if PD entry is a huge page - if so, we need to split it
             let pd_ref = &mut *pd;
-            let pt = self.get_or_create_table(&mut pd_ref.entries[vaddr.pd_index()], flags)?;
+            let pd_entry = &mut pd_ref.entries[vaddr.pd_index()];
+            
+            let pt = if pd_entry.is_present() && pd_entry.is_huge() {
+                // Split the 2MB huge page into 512 x 4KB pages
+                self.split_huge_page(pd_entry, flags)?
+            } else {
+                // Get or create PT normally
+                self.get_or_create_table(pd_entry, flags)?
+            };
 
             // Set the page table entry
             let pt_ref = &mut *pt;
@@ -389,6 +432,53 @@ impl PageTableManager {
         }
 
         Ok(())
+    }
+
+    /// Split a 2MB huge page into 512 x 4KB pages
+    /// Returns the virtual pointer to the new page table
+    unsafe fn split_huge_page(
+        &self,
+        pd_entry: &mut PageTableEntry,
+        flags: PageTableFlags,
+    ) -> Result<*mut PageTable, &'static str> {
+        // Get the base physical address of the huge page
+        let huge_page_phys = pd_entry.addr();
+        let old_flags = pd_entry.flags();
+        
+        // Allocate a new page table
+        let pt_phys = self.allocate_page_table_phys()
+            .ok_or("Failed to allocate page table for splitting huge page")?;
+        let pt = phys_to_ptr::<PageTable>(pt_phys);
+        
+        // Fill the page table with 512 entries mapping the same physical region
+        // Preserve the original flags but remove HUGE_PAGE and add USER_ACCESSIBLE if needed
+        let base_flags = if flags.contains(PageTableFlags::USER_ACCESSIBLE) {
+            old_flags.union(PageTableFlags::USER_ACCESSIBLE).difference(PageTableFlags::HUGE_PAGE)
+        } else {
+            old_flags.difference(PageTableFlags::HUGE_PAGE)
+        };
+        
+        for i in 0..PAGE_TABLE_ENTRIES {
+            let page_phys = huge_page_phys + (i * PAGE_SIZE_4K) as u64;
+            (*pt).entries[i].set(page_phys, base_flags);
+        }
+        
+        // Update the PD entry to point to the new page table
+        let table_flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE |
+            if flags.contains(PageTableFlags::USER_ACCESSIBLE) {
+                PageTableFlags::USER_ACCESSIBLE
+            } else {
+                PageTableFlags::empty()
+            };
+        pd_entry.set(pt_phys, table_flags);
+        
+        // Flush TLB for the entire 2MB region
+        let virt_base = huge_page_phys; // For identity mapping, virt == phys
+        for i in 0..PAGE_TABLE_ENTRIES {
+            invalidate_page(virt_base + (i * PAGE_SIZE_4K) as u64);
+        }
+        
+        Ok(pt)
     }
 
     /// Map a 2MB huge page
@@ -428,6 +518,15 @@ impl PageTableManager {
     ) -> Result<*mut PageTable, &'static str> {
         if entry.is_present() {
             // Table already exists - entry contains physical address
+            // If we need USER_ACCESSIBLE and it's not set, update the entry
+            let current_flags = entry.flags();
+            if flags.contains(PageTableFlags::USER_ACCESSIBLE) 
+                && !current_flags.contains(PageTableFlags::USER_ACCESSIBLE) 
+            {
+                // Add USER_ACCESSIBLE flag to existing entry
+                let new_flags = current_flags | PageTableFlags::USER_ACCESSIBLE;
+                entry.set(entry.addr(), new_flags);
+            }
             // Convert to virtual address for access
             let phys = entry.addr();
             Ok(phys_to_ptr::<PageTable>(phys))


### PR DESCRIPTION
# Implement Exit Syscall and Process-Based Execution

## Summary

This PR implements the `exit` syscall (syscall number 60, Linux-compatible) and transitions the OS to a process-based execution model. User programs can now properly terminate using `exit()`, and the kernel manages them as independent processes with full lifecycle support.

## Key Changes

### Exit Syscall
- Added `exit(status)` function to `horse_syscall` library
- Implemented `sys_exit()` kernel handler that terminates current process and switches to next
- Updated `gallop` user program to call `exit(0)` instead of infinite loop

### Process-Based Execution
- User programs now load as processes (not direct execution)
- Added `init_user_context()` to set up user-mode CPU context (USER_CS/USER_SS segments)
- Implemented process lifecycle management:
  - `terminate_current()` - Remove and switch away from current process
  - `prepare_switch()` / `prepare_terminate()` - Safe context switching without holding locks
  - `do_switch_context()` - Perform switch after lock release

### Debugcon Module
- New `kernel/src/debugcon.rs` for QEMU debug output (port 0xE9)
- Provides `debugcon_print!()` and `debugcon_println!()` macros
- Enhanced page fault handler with detailed register dumps
- Usage: Run QEMU with `-debugcon stdio` or `-debugcon file:debug.log`

### Page Table Improvements
- Implemented `split_huge_page()` to split 2MB huge pages into 512 × 4KB pages
- Fixed `create_user_page_table()` to create independent page table copies
- Improved USER_ACCESSIBLE flag propagation
- Added `difference()` method for flag manipulation

### Concurrency Fixes
- Fixed deadlock in timer handler by using proper lock ordering
- Context switches now happen after releasing all locks
- Timer-based preemptive scheduling enabled

## Files Changed

**New:**
- `kernel/src/debugcon.rs`

**Modified:**
- `gallop/src/main.rs`
- `horse_syscall/src/{fs.rs, lib.rs, raw.rs}`
- `kernel/src/{main.rs, paging.rs, proc.rs, syscall.rs}`

## Testing

Tested with:
- User program successfully exits with `exit(0)`
- Process creation and termination works correctly
- Timer-based context switching between processes
- Page fault debugging via debugcon

This lays the foundation for multi-process support, `fork()`, and `wait()` syscalls.
